### PR TITLE
GAUD-8346 - Update browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ module.exports = [
 	'Chrome >= 67',
 	'Edge >= 79',
 	'Firefox >= 67',
-	'Safari >= 11',
-	'ios_saf >= 11',
+	'Safari >= 12',
+	'ios_saf >= 12',
 	'not ie 11',
 	'not dead'
 ];


### PR DESCRIPTION
Updating the browser versions to match what has been hard-blocked since January. I'll create a follow-up story to match what's been handblocked since July.

Running `npx browserslist` before and after, these are the browsers being removed:
```
safari 11
safari 11.1
ios_saf 11.0-11.2
ios_saf 11.3-11.4
```

Taking a look at the non-uglified version of BSI before and after, there seems to be three major things this gets us:

1. No longer polyfilling the spread operator (`...`) in Objects
2. No longer polyfilling async iterators (` for await`)
3. Catch binding is optional (no more `} catch (_unused) {`)

If you're interested, you can see all that [here](https://github.com/Brightspace/brightspace-integration/compare/current-browsers...new-browsers).